### PR TITLE
cmake: pass libusb include directory as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ endif()
 find_package(LibUSB)
 if (NOT LIBUSB_FOUND)
     add_subdirectory(externals/libusb)
+    set(LIBUSB_INCLUDE_DIR "")
     set(LIBUSB_LIBRARIES usb)
 endif()
 

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -30,6 +30,7 @@ if(SDL2_FOUND)
     target_compile_definitions(input_common PRIVATE HAVE_SDL2)
 endif()
 
+target_include_directories(input_common SYSTEM PUBLIC ${LIBUSB_INCLUDE_DIR})
 target_link_libraries(input_common PUBLIC ${LIBUSB_LIBRARIES})
 
 create_target_directory_groups(input_common)


### PR DESCRIPTION
In file included from src/input_common/gcadapter/gc_adapter.cpp:8:
src/./input_common/gcadapter/gc_adapter.h:11:10: fatal error: 'libusb.h' file not found
 #include <libusb.h>
          ^~~~~~~~~~

Fixes build issues on Linux.